### PR TITLE
Fix issue #3522 (WiFi does not restart after stopped) (#4114)

### DIFF
--- a/libraries/WiFi/src/WiFiGeneric.cpp
+++ b/libraries/WiFi/src/WiFiGeneric.cpp
@@ -574,7 +574,7 @@ bool WiFiGenericClass::mode(wifi_mode_t m)
  */
 wifi_mode_t WiFiGenericClass::getMode()
 {
-    if(!lowLevelInitDone){
+    if(!lowLevelInitDone || !_esp_wifi_started){
         return WIFI_MODE_NULL;
     }
     wifi_mode_t mode;


### PR DESCRIPTION
Assuming we don't want to simply update to the latest commit from the espressif upstream library, this cherry-picks in the fix from https://github.com/espressif/arduino-esp32/pull/4114

I have not yet tested this

This commit fixes issue https://github.com/espressif/arduino-esp32/issues/3522 where WiFi service fails to start after a WiFi.disconnect(true) or a WiFi.mode(WIFI_OFF).