### PR TITLE
Change in 80e9e42 from our upstream source.

### DIFF
--- a/libraries/WiFi/src/WiFiGeneric.cpp
+++ b/libraries/WiFi/src/WiFiGeneric.cpp
@@ -574,7 +574,7 @@ bool WiFiGenericClass::mode(wifi_mode_t m)
  */
 wifi_mode_t WiFiGenericClass::getMode()
 {
-    if(!lowLevelInitDone){
+    if(!lowLevelInitDone || !_esp_wifi_started){
         return WIFI_MODE_NULL;
     }
     wifi_mode_t mode;


### PR DESCRIPTION
Diff from upstream:

https://github.com/espressif/arduino-esp32/commit/80e9e42c3b7a8ad646cd8803c9f4f84e35c9ebb1